### PR TITLE
fix: WSHeartbeat add callback to re-register the instance

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -137,7 +137,11 @@ func TestRegistryClient_FindMicroServiceInstances(t *testing.T) {
 		iid, err := registryClient.RegisterMicroServiceInstance(microServiceInstance)
 		assert.NoError(t, err)
 		assert.NotNil(t, iid)
-		err = registryClient.WSHeartbeat(microServiceInstance.ServiceId, iid)
+		microServiceInstance.InstanceId = iid
+		callback := func() {
+			registryClient.RegisterMicroServiceInstance(microServiceInstance)
+		}
+		err = registryClient.WSHeartbeat(microServiceInstance.ServiceId, iid, callback)
 		assert.Nil(t, err)
 		ok, err := registryClient.UnregisterMicroServiceInstance(microServiceInstance.ServiceId, iid)
 		assert.NoError(t, err)


### PR DESCRIPTION
What type of PR is this?
/fix

What this PR does / why we need it:
add callback to re-register the instance

Which issue(s) this PR fixes:
Fixes #47

Special notes for your reviewer: @tianxiaoliang @little-cui

Use case description:

There is no need to add a new use case. Previously, the related function use case has been included.

Does this PR introduce a user-facing change?

No

Additional documentation e.g., usage docs, etc.:

No

Verify

1. Register an instance, use a long connection to send a heartbeat, and then delete

![image](https://user-images.githubusercontent.com/27326092/130207613-cc6a880d-2261-4c48-b9a7-6dfe99f61dc8.png)

2. try to re-register

![image](https://user-images.githubusercontent.com/27326092/130207732-d0a58efa-58ca-4278-baa5-2230dfaefcdf.png)

![image](https://user-images.githubusercontent.com/27326092/130207759-679ab876-9436-4c62-8537-90806eeda0cc.png)


