### PR TITLE
fix: WSHeartbeat add callback to re-register the instance

### DIFF
--- a/client.go
+++ b/client.go
@@ -695,7 +695,8 @@ func (c *Client) Heartbeat(microServiceID, microServiceInstanceID string) (bool,
 // WSHeartbeat creates a web socket connection to service-center to send heartbeat.
 // It relies on the ping pong mechanism of websocket to ensure the heartbeat, which is maintained by goroutines.
 // After the connection is established, the communication fails and will be retried continuously. The retrial time increases exponentially.
-func (c *Client) WSHeartbeat(microServiceID, microServiceInstanceID string) error {
+// The callback function is used to re-register the instance.
+func (c *Client) WSHeartbeat(microServiceID, microServiceInstanceID string, callback func()) error {
 	err := c.setupWSConnection(microServiceID, microServiceInstanceID)
 	if err != nil {
 		return err
@@ -709,7 +710,14 @@ func (c *Client) WSHeartbeat(microServiceID, microServiceInstanceID string) erro
 			_, _, err = conn.ReadMessage()
 			if err != nil {
 				openlog.Error(err.Error())
-				conn.Close()
+				err = conn.Close()
+				if err != nil {
+					openlog.Error(fmt.Sprintf("failed to close websocket connection %s", err.Error()))
+				}
+				if websocket.IsCloseError(err, discovery.ErrWebsocketInstanceNotExists) {
+					// If the instance does not exist, it is closed normally and should be re-registered
+					callback()
+				}
 				// reconnection
 				err = backoff.RetryNotify(
 					resetConn,
@@ -743,7 +751,7 @@ func (c *Client) setupWSConnection(microServiceID, microServiceInstanceID string
 		return err
 	}
 	c.conns[microServiceInstanceID] = conn
-	openlog.Info(fmt.Sprintf("%s's websocket connection established successfully",microServiceInstanceID))
+	openlog.Info(fmt.Sprintf("%s's websocket connection established successfully", microServiceInstanceID))
 	return nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -137,7 +137,11 @@ func TestRegistryClient_FindMicroServiceInstances(t *testing.T) {
 		iid, err := registryClient.RegisterMicroServiceInstance(microServiceInstance)
 		assert.NoError(t, err)
 		assert.NotNil(t, iid)
-		err = registryClient.WSHeartbeat(microServiceInstance.ServiceId, iid)
+		microServiceInstance.InstanceId = iid
+		callback := func() {
+			registryClient.RegisterMicroServiceInstance(microServiceInstance)
+		}
+		err = registryClient.WSHeartbeat(microServiceInstance.ServiceId, iid, callback)
 		assert.Nil(t, err)
 		ok, err := registryClient.UnregisterMicroServiceInstance(microServiceInstance.ServiceId, iid)
 		assert.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/go-chassis/sc-client
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.1
-	github.com/go-chassis/cari v0.4.0
+	github.com/go-chassis/cari v0.5.1-0.20210823023004-74041d1363c4
 	github.com/go-chassis/foundation v0.3.0
 	github.com/go-chassis/openlog v1.1.2
 	github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInq
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
-github.com/go-chassis/cari v0.4.0 h1:2rJ7pB4dfZIu5/HQwwJhmybC1n/0MXWkKieoHCu4tQc=
-github.com/go-chassis/cari v0.4.0/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
+github.com/go-chassis/cari v0.5.1-0.20210823023004-74041d1363c4 h1:FTbuN+IqSX17ulICGJqr357o8dGWqtfUdLtztLvIiRI=
+github.com/go-chassis/cari v0.5.1-0.20210823023004-74041d1363c4/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
 github.com/go-chassis/foundation v0.3.0 h1:jG4BIrK8fXD9jbTtJ5rOLGQZ1pQI/mLnDuVJzToCtos=
 github.com/go-chassis/foundation v0.3.0/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27pNeYaiE3ZxOBA=
 github.com/go-chassis/openlog v1.1.2 h1:LgGfwwOhpU8c6URV6ADpaRBPVY7Ph1C28jCQ6zzQawQ=


### PR DESCRIPTION
What type of PR is this?
/fix

What this PR does / why we need it:
add callback to re-register the instance

Which issue(s) this PR fixes:
Fixes #47

Special notes for your reviewer: @tianxiaoliang @little-cui

Use case description:

There is no need to add a new use case. Previously, the related function use case has been included.

Does this PR introduce a user-facing change?

No

Additional documentation e.g., usage docs, etc.:

No

Verify

1. Register an instance, use a long connection to send a heartbeat, and then delete

![image](https://user-images.githubusercontent.com/27326092/130207613-cc6a880d-2261-4c48-b9a7-6dfe99f61dc8.png)

2. try to re-register

![image](https://user-images.githubusercontent.com/27326092/130207732-d0a58efa-58ca-4278-baa5-2230dfaefcdf.png)

![image](https://user-images.githubusercontent.com/27326092/130207759-679ab876-9436-4c62-8537-90806eeda0cc.png)


