### PR TITLE
默认打开client endpoint health check

### DIFF
--- a/client.go
+++ b/client.go
@@ -115,6 +115,7 @@ func NewClient(opt Options) (*Client, error) {
 	//Update the API Base Path based on the project
 	c.updateAPIPath()
 	c.pool.SetAddress(opt.Endpoints)
+	c.pool.Monitor()
 	return c, nil
 }
 
@@ -131,7 +132,6 @@ func (c *Client) updateAPIPath() {
 // if your service center cluster is not behind a load balancing service like ELB,nginx etc
 // then you can use this function
 func (c *Client) SyncEndpoints() error {
-	c.pool.Monitor()
 	instances, err := c.Health()
 	if err != nil {
 		return fmt.Errorf("sync SC ep failed. err:%s", err.Error())


### PR DESCRIPTION
endpoint健康检查是解决“部分endpoint不可用导致调用失败”问题，该问题在普通的调用中就要解决，而非只在endpoint同步时才要解决，因此默认开启。