### PR TITLE
Remove the revision in the client

### DIFF
--- a/options.go
+++ b/options.go
@@ -41,6 +41,13 @@ func WithoutRevision() CallOption {
 	}
 }
 
+// WithRevision query resources with the revision
+func WithRevision(revision string) CallOption {
+	return func(o *CallOptions) {
+		o.Revision = revision
+	}
+}
+
 // WithGlobal query resources include other aggregated SC
 func WithGlobal() CallOption {
 	return func(o *CallOptions) {

--- a/response.go
+++ b/response.go
@@ -5,25 +5,25 @@ import (
 )
 
 const (
-	//EventCreate is a constant of type string
+	// EventCreate is a constant of type string
 	EventCreate string = "CREATE"
-	//EventUpdate is a constant of type string
+	// EventUpdate is a constant of type string
 	EventUpdate string = "UPDATE"
-	//EventDelete is a constant of type string
+	// EventDelete is a constant of type string
 	EventDelete string = "DELETE"
-	//EventError is a constant of type string
+	// EventError is a constant of type string
 	EventError string = "ERROR"
-	//MicorserviceUp is a constant of type string
+	// MicorserviceUp is a constant of type string
 	MicorserviceUp string = "UP"
-	//MicroserviceDown is a constant of type string
+	// MicroserviceDown is a constant of type string
 	MicroserviceDown string = "DOWN"
-	//MSInstanceUP is a constant of type string
+	// MSInstanceUP is a constant of type string
 	MSInstanceUP string = "UP"
-	//MSIinstanceDown is a constant of type string
+	// MSIinstanceDown is a constant of type string
 	MSIinstanceDown string = "DOWN"
-	//CheckByHeartbeat is a constant of type string
+	// CheckByHeartbeat is a constant of type string
 	CheckByHeartbeat string = "push"
-	//DefaultLeaseRenewalInterval is a constant of type int which declares default lease renewal time
+	// DefaultLeaseRenewalInterval is a constant of type int which declares default lease renewal time
 	DefaultLeaseRenewalInterval = 30
 )
 
@@ -37,4 +37,9 @@ type MicroServiceInstanceChangedEvent struct {
 	Action   string                          `protobuf:"bytes,2,opt,name=action" json:"action,omitempty"`
 	Key      *discovery.MicroServiceKey      `protobuf:"bytes,3,opt,name=key" json:"key,omitempty"`
 	Instance *discovery.MicroServiceInstance `protobuf:"bytes,4,opt,name=instance" json:"instance,omitempty"`
+}
+
+type FindMicroServiceInstancesResult struct {
+	Instances []*discovery.MicroServiceInstance
+	Revision  string
 }


### PR DESCRIPTION
Remove the revision in the client, and support to input/output the revision instead.